### PR TITLE
[INFRA] Générer automatiquement le CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# ING4-DevOps-Project Changelog

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "release:minor": "npm version minor -m \"Release v%s\"",
     "release:major": "npm version major -m \"Release v%s\"",
     "preversion": "git checkout dev && git pull --rebase && npm test",
+    "version": "node scripts/release/get-pull-requests-to-release-in-prod.js && git add package.json CHANGELOG.md",
     "postversion": "git push && git checkout master && git pull && git fetch -t && git merge dev --no-edit && git push origin master && git push --tags && git checkout dev"
   },
   "repository": {

--- a/scripts/.eslintrc.yaml
+++ b/scripts/.eslintrc.yaml
@@ -1,0 +1,4 @@
+extends: '../.eslintrc.yaml'
+
+globals:
+  include: true

--- a/scripts/release/get-pull-requests-to-release-in-prod.js
+++ b/scripts/release/get-pull-requests-to-release-in-prod.js
@@ -1,0 +1,111 @@
+#! /usr/bin/env node
+require('dotenv').config()
+const axios = require('axios')
+const dayjs = require('dayjs')
+const _ = require('lodash')
+const fs = require('fs')
+const { version } = require('../../package.json')
+
+const CHANGELOG_FILE = 'CHANGELOG.md'
+const CHANGELOG_HEADER_LINES = 2
+
+function getAuthentification() {
+  return {
+    username: process.env.GITHUB_USERNAME,
+    password: process.env.GITHUB_PERSONAL_ACCESS_TOKEN,
+  }
+}
+
+function buildRequestObject() {
+  return {
+    url:
+      'https://api.github.com/repos/VincentHardouin/ING4-DevOps-Project/pulls?state=closed&sort=updated&direction=desc',
+    auth: getAuthentification(),
+  }
+}
+
+function getTheLastCommitOnMaster() {
+  return {
+    url:
+      'https://api.github.com/repos/VincentHardouin/ING4-DevOps-Project/commits/master',
+    auth: getAuthentification(),
+  }
+}
+
+function getTheCommitDate(RawDataCommit) {
+  return RawDataCommit.commit.committer.date
+}
+
+function displayPullRequest(pr) {
+  return `- [#${pr.number}](${pr.html_url}) ${pr.title}`
+}
+
+function orderPr(listPR) {
+  const typeOrder = ['FEATURE', 'REFACTO', 'BUGFIX', 'TECH']
+  return _.sortBy(listPR, (pr) => {
+    const typeOfPR = pr.title.substring(1, pr.title.indexOf(']'))
+    const typeIndex = _.indexOf(typeOrder, typeOfPR)
+    return typeIndex < 0 ? Number.MAX_VALUE : typeIndex
+  })
+}
+
+function filterPullRequest(pullrequests, dateOfLastMEP) {
+  return pullrequests.filter((PR) => PR.merged_at > dateOfLastMEP)
+}
+
+function getHeadOfChangelog(tagVersion) {
+  const date = ' (' + dayjs().format('DD/MM/YYYY') + ')'
+  return '## v' + tagVersion + date + '\n'
+}
+
+function main() {
+  const tagVersion = process.argv[2] || version
+  let dateOfLastMEP
+
+  axios(getTheLastCommitOnMaster())
+    .then(({ data: lastCommit }) => {
+      dateOfLastMEP = getTheCommitDate(lastCommit)
+      return axios(buildRequestObject())
+    })
+    .then(({ data: pullRequests }) => {
+      const newChangeLogLines = []
+
+      newChangeLogLines.push(getHeadOfChangelog(tagVersion))
+      const pullRequestsSinceLastMEP = filterPullRequest(
+        pullRequests,
+        dateOfLastMEP
+      )
+
+      const orderedPR = orderPr(pullRequestsSinceLastMEP)
+      newChangeLogLines.push(...orderedPR.map(displayPullRequest))
+      newChangeLogLines.push('')
+
+      const currentChangeLog = fs
+        .readFileSync(CHANGELOG_FILE, 'utf-8')
+        .split('\n')
+
+      currentChangeLog.splice(CHANGELOG_HEADER_LINES, 0, ...newChangeLogLines)
+
+      console.log(`Writing to ${CHANGELOG_FILE}`)
+
+      fs.writeFileSync(CHANGELOG_FILE, currentChangeLog.join('\n'))
+    })
+    .catch((e) => {
+      console.log(e)
+      process.exit(1)
+    })
+}
+
+/*=================== tests =============================*/
+
+if (process.env.NODE_ENV !== 'test') {
+  main()
+} else {
+  module.exports = {
+    displayPullRequest,
+    filterPullRequest,
+    orderPr,
+    getHeadOfChangelog,
+    getTheCommitDate,
+  }
+}

--- a/scripts/tests/.eslintrc.yaml
+++ b/scripts/tests/.eslintrc.yaml
@@ -1,0 +1,2 @@
+env:
+  mocha: true

--- a/scripts/tests/get-pull-requests-to-release-in-prod_test.js
+++ b/scripts/tests/get-pull-requests-to-release-in-prod_test.js
@@ -1,0 +1,149 @@
+const { expect } = require('chai')
+const sinon = require('sinon')
+
+const {
+  displayPullRequest,
+  filterPullRequest,
+  getHeadOfChangelog,
+  orderPr,
+  getTheCommitDate,
+} = require('../release/get-pull-requests-to-release-in-prod')
+
+describe('Unit | Script | GET Pull Request to release in Prod', () => {
+  describe('displayPullRequest', () => {
+    const expectedLine =
+      '- [#111](http://git/111) [BUGFIX] Résolution du problème de surestimation du niveau (US-389).'
+
+    it('should return a line with correct format from correct PR name', () => {
+      // given
+      const pullRequest = {
+        title:
+          '[BUGFIX] Résolution du problème de surestimation du niveau (US-389).',
+        number: 111,
+        html_url: 'http://git/111',
+      }
+      // when
+      const result = displayPullRequest(pullRequest)
+      // then
+      expect(result).to.equal(expectedLine)
+    })
+  })
+
+  describe('filterPullRequest', () => {
+    it('should return only merged PR since last MEP', () => {
+      // given
+      const date = '2019-01-18T15:29:51Z'
+      const pullRequests = [
+        {
+          id: 1,
+          number: 315,
+          state: 'closed',
+          title:
+            '[BUGFIX] Retenter une compétence doit créer une nouvelle évaluation sur la compétence (et non en reprendre une ancienne) (PF-484).',
+          created_at: '2019-01-11T15:47:26Z',
+          updated_at: '2019-01-23T13:37:47Z',
+          closed_at: '2019-01-23T13:37:37Z',
+          merged_at: '2019-01-23T13:37:37Z',
+          assignee: null,
+          milestone: null,
+        },
+        {
+          id: 2,
+          number: 316,
+          state: 'closed',
+          title:
+            '[BUGFIX] Retenter une compétence doit créer une nouvelle évaluation sur la compétence (et non en reprendre une ancienne) (PF-484).',
+          created_at: '2018-01-11T15:47:26Z',
+          updated_at: '2018-01-23T13:37:47Z',
+          closed_at: '2018-01-23T13:37:37Z',
+          merged_at: '2018-01-23T13:37:37Z',
+          assignee: null,
+          milestone: null,
+        },
+        {
+          id: 3,
+          number: 317,
+          state: 'closed',
+          title:
+            '[BUGFIX] Retenter une compétence doit créer une nouvelle évaluation sur la compétence (et non en reprendre une ancienne) (PF-484).',
+          created_at: '2019-01-11T15:47:26Z',
+          updated_at: '2019-01-23T13:37:47Z',
+          closed_at: '2019-01-23T13:37:37Z',
+          merged_at: null,
+          assignee: null,
+          milestone: null,
+        },
+      ]
+
+      // when
+      const result = filterPullRequest(pullRequests, date)
+      // then
+      expect(result.length).to.equal(1)
+      expect(result[0].id).to.equal(1)
+    })
+  })
+
+  describe('getHeadOfChangelog', () => {
+    it('should return the head of changelog in correct value', () => {
+      // given
+      sinon.useFakeTimers()
+      const headChangelog = '## v2.0.0 (01/01/1970)\n'
+      const versionNumber = '2.0.0'
+      // when
+      const result = getHeadOfChangelog(versionNumber)
+      // then
+      expect(result).to.equal(headChangelog)
+    })
+  })
+
+  describe('orderPr', () => {
+    it('should order PR by type', () => {
+      // given
+      const pullRequests = [
+        { title: '[BUGFIX] TEST' },
+        { title: '[REFACTO] TEST' },
+        { title: 'TEST' },
+        { title: '[FEATURE] TEST' },
+        { title: '[TECH] TEST' },
+      ]
+      // when
+      const result = orderPr(pullRequests)
+      // then
+      expect(result[0].title).to.equal('[FEATURE] TEST')
+      expect(result[1].title).to.equal('[REFACTO] TEST')
+      expect(result[2].title).to.equal('[BUGFIX] TEST')
+      expect(result[3].title).to.equal('[TECH] TEST')
+      expect(result[4].title).to.equal('TEST')
+    })
+  })
+
+  describe('getTheCommitDate', () => {
+    it('should return the date of the commit', () => {
+      // given
+      const RawDataCommit = {
+        sha: 'ada4',
+        node_id: 'MDY6Q29',
+        commit: {
+          author: {
+            name: 'petitPix',
+            email: 'petit.pix@gexample.net',
+            date: '2019-01-18T15:29:51Z',
+          },
+          committer: {
+            name: 'petitPix',
+            email: 'petit.pix@gexample.net',
+            date: '2019-01-18T15:29:51Z',
+          },
+        },
+      }
+
+      const expectedDate = '2019-01-18T15:29:51Z'
+
+      // when
+      const result = getTheCommitDate(RawDataCommit)
+
+      // then
+      expect(result).to.equal(expectedDate)
+    })
+  })
+})


### PR DESCRIPTION
## :unicorn: Problème
Actuellement nous devons générer le changelog à la main, c'est long et fastidieux.

## :robot: Solution
Générer automatiquement le changelog à partir des PR mergées.