### PR TITLE
[TECH] Ajouter un template de création de Review App

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -1,0 +1,18 @@
+{
+  "name": "DevOps Project Review App",
+  "env": {
+    "DATABASE_REDIS_URL": {
+      "description": "",
+      "value": "$REDIS_URL"
+    }
+  },
+  "addons": [
+    "redis:redis-sandbox"
+  ],
+  "formation": {
+    "web": {
+      "amount": 1,
+      "size": "S"
+    }
+  }
+}


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, lorsqu'une Review App est ouverte, il n'y a pas de Redis, on ne peut pas alors tester l'application convenablement.

## :robot: Solution
Ajouter un fichier `scalingo.json` avec le template des Review App que l'on souhaite

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se rendre sur la review app et voir qu'on peut bien utiliser l'application
