### PR TITLE
[INFRA] Utiliser les tags de version plutôt que latest

### DIFF
--- a/k8s/deployments/node-app-deployment.yaml
+++ b/k8s/deployments/node-app-deployment.yaml
@@ -1,24 +1,29 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: devops-project-deployment
+  name: devops-project-deployment-v0.6.0
   labels:
     app: web
+    version: v0.6.0
 spec:
   replicas: 3
   selector:
     matchLabels:
       app: web
+      version: v0.6.0
   template:
     metadata:
       labels:
         app: web
+        version: v0.6.0
     spec:
       containers:
         - name: web
-          image: nidourah/ece-devops-project
+          image: nidourah/ece-devops-project:v0.6.0
           ports:
             - containerPort: 3000
           env:
             - name: DATABASE_REDIS_URL
               value: redis://redis-service:6379
+            - name: AUTH_SECRET
+              value: "secret"


### PR DESCRIPTION
## :unicorn: Problème
Actuellement dans notre déploiement via K8s nous utilisons le tag latest qui est par défaut cependant ce n'est pas une bonne pratique. 

## :robot: Solution
Utiliser les tags de versions

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
